### PR TITLE
Feature: Personal lists and secure account management

### DIFF
--- a/popcorn_journal_app/models.py
+++ b/popcorn_journal_app/models.py
@@ -17,6 +17,12 @@ watchlist_items = db.Table('watchlist_items',
     db.Column('movie_id', db.Integer, db.ForeignKey('movie.id'), primary_key=True)
 )
 
+# Association table for lists of movies (many-to-many relationship)
+list_movies = db.Table('list_movies',
+    db.Column('list_id', db.Integer, db.ForeignKey('list.id'), primary_key=True),
+    db.Column('movie_id', db.Integer, db.ForeignKey('movie.id'), primary_key=True)
+)
+
 class User(db.Model, UserMixin):
     # USER INFO
     id = db.Column(db.Integer, primary_key=True)
@@ -30,7 +36,8 @@ class User(db.Model, UserMixin):
     profile_pic = db.Column(db.String(120), default='user.png')
     bio = db.Column(db.String(256), nullable=True)
     watchlist = db.relationship('Movie', secondary=watchlist_items, backref=db.backref('interested_users', lazy='dynamic'))
-    reviews = db.relationship('Review', backref='reviewer', lazy=True)
+    reviews = db.relationship('Review', backref='author', cascade='all, delete-orphan')
+    lists = db.relationship('List', backref='owner', cascade='all, delete-orphan')
 
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)
@@ -106,14 +113,12 @@ class Review(db.Model):
     date_posted = db.Column(db.DateTime, default=db.func.now())
     like_count = db.Column(db.Integer, default=0)
 
-    author = db.relationship('User', backref='my_reviews', lazy=True)
-
     def __repr__(self):
         return f'<Review {self.id} by {self.user_id}>'
     
 class List(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id')) # owner of the list
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False) # owner of the list
     name = db.Column(db.String(128)) # name of the list
     description = db.Column(db.Text) # description of the list
     public_status = db.Column(db.Boolean, default=False) # public or private list, default = private
@@ -121,6 +126,7 @@ class List(db.Model):
     content_type = db.Column(db.String(10))  # 'movie' or 'series' or 'mixed'
     content_ids = db.Column(db.String) # comma-separated list of movie/series IDs
     follower_count = db.Column(db.Integer, default=0) # number of followers for the list
+    movies = db.relationship('Movie', secondary='list_movies', backref='contained_in_lists')
     
     def __repr__(self):
         return f'<List {self.name} by User {self.user_id}>'

--- a/popcorn_journal_app/routes.py
+++ b/popcorn_journal_app/routes.py
@@ -53,34 +53,31 @@ def profile():
 
     return render_template('profile.html', title='Profile - Popcorn Journal', user=user, follower_count=follower_count, following_count=following_count)
 
-@bp.route('/delete/<int:user_id>', methods=['POST']) # delete user account
+@bp.route('/user/delete/<int:user_id>', methods=['POST']) # delete user account
 @login_required
 def delete_user(user_id):
-    user = User.query.filter_by(id=user_id).first()
-    if user == current_user:
-        db.session.delete(user)
-        db.session.commit()
-        flash('Your account has been deleted.')
-        return redirect(url_for('main.index'))
-    if not user == current_user:
+    if user_id != current_user.id:
         flash('You can only delete your own account.')
         return redirect(url_for('main.profile'))
-    else:
-        flash('There was an error in your request. Please try again.')
-        return redirect(url_for('main.index'))
     
-@bp.route('/delete/<int:list_id>', methods=['POST']) # delete list
+    user = User.query.get_or_404(user_id)
+    logout_user()
+    db.session.delete(user)
+    db.session.commit()
+    flash('Your account and all associated data have been deleted.')
+    return redirect(url_for('main.index'))
+    
+@bp.route('/list/delete/<int:list_id>', methods=['POST']) # delete list
 @login_required
 def delete_list(list_id):
-    list_to_delete = List.query.filter_by(id=list_id).first()
-    if list_to_delete and list_to_delete.user_id == current_user.id:
-        db.session.delete(list_to_delete)
-        db.session.commit()
-        flash(f'Your list {list_to_delete.name} has been deleted.')
-        return redirect(url_for('main.profile'))
-    else:
-        flash('You can only delete your own lists.')
-        return redirect(url_for('main.profile'))
+    list_to_delete = List.query.get_or_404(list_id)
+    if list_to_delete.user_id != current_user.id:
+        flash('You can only delete your own lists.', 'danger')
+        return redirect(url_for('main.lists'))
+    db.session.delete(list_to_delete)
+    db.session.commit()
+    flash(f'List "{list_to_delete.name}" has been deleted.', 'success')
+    return redirect(url_for('main.lists'))
 
 @bp.route('/user/<int:user_id>') # view another user's page
 def other_user(user_id):
@@ -189,11 +186,8 @@ def toggle_watchlist(movie_id):
 # Browse Lists page - shows all lists created by users, with option to click into each list to see the movies/series in that list
 @bp.route('/lists')
 def lists():
-    mock_lists = [
-        {'id': 3, 'name': 'Films Directed by Women', 'description': 'My favourite women-directed films.', 'movies': [1, 2, 3]},
-        {'id': 2, 'name': 'Cozy Rainy Day Movies', 'description': 'Movies for cozy rainy days.', 'movies': [1, 2]}
-    ]
-    return render_template('lists.html', lists=mock_lists, title = 'Lists - Popcorn Journal')
+    user_lists = List.query.filter_by(user_id=current_user.id).all()
+    return render_template('lists.html', title='My Lists', lists=user_lists)
 
 # View personal page of lists - flow of webpages: click list on this page > list's page with contents > click movie/series > movie/series page with details and reviews
 #@bp.route('/list/<int:list_id>')
@@ -355,3 +349,88 @@ def delete_movie(movie_id):
     db.session.commit()
     flash("Movie deleted from the database.", "info")
     return redirect(url_for('main.search'))
+
+# LISTS functionality
+# Adding movie to list
+@bp.route('/list/add-movie/<int:movie_id>', methods=['POST'])
+@login_required
+def add_to_list(movie_id):
+    movie = Movie.query.get_or_404(movie_id)
+    list_id = request.form.get('list_id')
+    
+    if not list_id:
+        flash("Please select a list.", "warning")
+        return redirect(url_for('main.movie_detail', movie_id=movie_id))
+    
+    user_list = List.query.get_or_404(list_id)
+    
+    if user_list.user_id != current_user.id:
+        flash("You do not have permission to modify this list.", "danger")
+        return redirect(url_for('main.movie_detail', movie_id=movie_id))
+    
+    if movie in user_list.movies:
+        flash(f"'{movie.title}' is already in your list: {user_list.name}", "info")
+    else:
+        user_list.movies.append(movie)
+        db.session.commit()
+        flash(f"Added '{movie.title}' to {user_list.name}!", "success")
+        
+    return redirect(url_for('main.movie_detail', movie_id=movie_id))
+
+# Creating a list
+@bp.route('/list/create', methods=['POST'])
+@login_required
+def create_list():
+    name = request.form.get('name')
+    description = request.form.get('description')
+    public_status = True if request.form.get('public_status') == 'on' else False
+
+    if not name:
+        flash("List name is required!", "warning")
+        return redirect(url_for('main.lists'))
+
+    new_list = List(
+        name=name,
+        description=description,
+        public_status=public_status,
+        user_id=current_user.id
+    )
+
+    db.session.add(new_list)
+    db.session.commit()
+    
+    flash(f"List '{name}' created successfully!", "success")
+    return redirect(url_for('main.lists'))
+
+# Viewing a list
+@bp.route('/list/<int:list_id>')
+@login_required
+def view_list(list_id):
+    user_list = List.query.get_or_404(list_id)
+    
+    if not user_list.public_status and user_list.user_id != current_user.id:
+        flash("You do not have permission to view this private list.", "danger")
+        return redirect(url_for('main.lists'))
+        
+    return render_template('list_detail.html', title=user_list.name, user_list=user_list)
+
+# Removing movie from a list
+@bp.route('/list/<int:list_id>/remove-movie/<int:movie_id>', methods=['POST'])
+@login_required
+def remove_from_list(list_id, movie_id):
+    user_list = List.query.get_or_404(list_id)
+    
+    if user_list.user_id != current_user.id:
+        flash("You do not have permission to modify this list.", "danger")
+        return redirect(url_for('main.view_list', list_id=list_id))
+    
+    movie = Movie.query.get_or_404(movie_id)
+    
+    if movie in user_list.movies:
+        user_list.movies.remove(movie)
+        db.session.commit()
+        flash(f"'{movie.title}' removed from {user_list.name}.", "info")
+    else:
+        flash("Movie not found in this list.", "warning")
+        
+    return redirect(url_for('main.view_list', list_id=list_id))

--- a/popcorn_journal_app/static/js/settings.js
+++ b/popcorn_journal_app/static/js/settings.js
@@ -1,0 +1,28 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const deleteBtn = document.getElementById("delete-account-btn");
+
+  if (deleteBtn) {
+    deleteBtn.addEventListener("click", function () {
+      const userId = this.getAttribute("data-user-id");
+      const csrfToken = this.getAttribute("data-csrf");
+
+      if (confirm("Are you sure? This will delete your account and all your reviews/lists forever.")) {
+        fetch(`/user/delete/${userId}`, {
+          method: "POST",
+          headers: {
+            "X-CSRFToken": csrfToken,
+          },
+        })
+          .then((response) => {
+            if (response.redirected) {
+              window.location.href = response.url;
+            }
+          })
+          .catch((error) => {
+            console.error("Error:", error);
+            alert("An error occurred while deleting the account.");
+          });
+      }
+    });
+  }
+});

--- a/popcorn_journal_app/templates/list_detail.html
+++ b/popcorn_journal_app/templates/list_detail.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %} {% block content %}
+<div class="container py-5">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="{{ url_for('main.lists') }}">My Lists</a></li>
+      <li class="breadcrumb-item active">{{ user_list.name }}</li>
+    </ol>
+  </nav>
+
+  <div class="mb-4">
+    <h1 class="fw-bold">{{ user_list.name }}</h1>
+    <p class="text-secondary">{{ user_list.description or "No description provided." }}</p>
+  </div>
+
+  <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4">
+    {% for movie in user_list.movies %}
+    <div class="col">
+      <div class="card h-100 border-0 shadow-sm overflow-hidden">
+        {% if movie.movie_img %}
+        <img
+          src="{{ url_for('static', filename='posters/' + movie.movie_img) }}"
+          class="card-img-top"
+          alt="{{ movie.title }}"
+          style="height: 300px; object-fit: cover"
+        />
+        {% else %}
+        <img src="https://picsum.photos/400/600" class="card-img-top" alt="Placeholder" style="height: 300px; object-fit: cover" />
+        {% endif %}
+
+        <div class="card-body d-flex flex-column">
+          <h5 class="card-title fw-bold text-truncate mb-1">{{ movie.title }}</h5>
+          <p class="text-muted small mb-3">{{ movie.release_year }} • Directed by {{ movie.director }}</p>
+
+          <div class="mt-auto">
+            <div class="d-grid gap-2">
+              <a href="{{ url_for('main.movie_detail', movie_id=movie.id) }}" class="btn btn-outline-main btn-sm">
+                <i class="bi bi-eye me-1"></i> View Details
+              </a>
+              <form
+                action="{{ url_for('main.remove_from_list', list_id=user_list.id, movie_id=movie.id) }}"
+                method="POST"
+                onsubmit="return confirm('Remove this movie from the list?');"
+              >
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                <button type="submit" class="btn btn-outline-danger btn-sm w-100"><i class="bi bi-trash me-1"></i> Remove</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% else %}
+    <div class="col-12">
+      <div class="alert alert-light text-center border py-5">
+        <p class="mb-3">This list is currently empty.</p>
+        <a href="{{ url_for('main.search') }}" class="btn btn-main btn-sm">Find Movies to Add</a>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/popcorn_journal_app/templates/lists.html
+++ b/popcorn_journal_app/templates/lists.html
@@ -1,86 +1,78 @@
-{% extends "base.html" %} 
-{% block title %}{{ title }}{% endblock %} 
-{% block content %}
+{% extends "base.html" %} {% block title %}{{ title }}{% endblock %} {% block content %}
 <div class="container py-5">
   <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
       <h1 class="fw-bold" id="title">My Lists</h1>
-      <p class="text-secondary mb-0">
-        Organise and manage your cinematic collections.
-      </p>
+      <p class="text-secondary mb-0">Organise and manage your cinematic collections.</p>
     </div>
-    <a href="#" class="btn btn-main">
+    <button type="button" class="btn btn-main" data-bs-toggle="modal" data-bs-target="#createListModal">
       <i class="bi bi-plus-lg me-2"></i> Create New List
-    </a>
+    </button>
   </div>
 
   <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+    {% for list in lists %}
     <div class="col">
       <div class="card h-100 shadow-sm border-0">
         <div class="card-body p-4 d-flex flex-column">
           <div class="d-flex justify-content-between align-items-start mb-2">
-            <h5 class="card-title fw-bold mb-0">My Favorites</h5>
-            <span class="badge bg-light text-dark border">Public</span>
+            <h5 class="card-title fw-bold mb-0">{{ list.name }}</h5>
+            <span class="badge bg-light text-dark border"> {{ 'Public' if list.public_status else 'Private' }} </span>
           </div>
-          <p class="card-text text-secondary small mb-4">
-            The absolute best movies I have ever seen. High re-watch value.
-          </p>
+          <p class="card-text text-secondary small mb-4">{{ list.description or "No description provided." }}</p>
 
           <div class="mt-auto">
-            <p class="text-secondary small mb-3">
-              <i class="bi bi-collection-play me-1"></i> 12 movies
-            </p>
-            <div class="d-grid">
-              <a href="#" class="btn btn-outline-secondary btn-sm">View List</a>
+            <p class="text-secondary small mb-3"><i class="bi bi-collection-play me-1"></i> {{ list.movies|length }} movies</p>
+            <div class="d-grid gap-2">
+              <a href="{{ url_for('main.view_list', list_id=list.id) }}" class="btn btn-outline-secondary btn-sm">View List</a>
+              <form
+                action="{{ url_for('main.delete_list', list_id=list.id) }}"
+                method="POST"
+                onsubmit="return confirm('Are you sure you want to delete this list?');"
+              >
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                <button type="submit" class="btn btn-outline-danger btn-sm w-100"><i class="bi bi-trash me-1"></i> Delete List</button>
+              </form>
             </div>
           </div>
         </div>
       </div>
     </div>
-
-    <div class="col">
-      <div class="card h-100 shadow-sm border-0">
-        <div class="card-body p-4 d-flex flex-column">
-          <div class="d-flex justify-content-between align-items-start mb-2">
-            <h5 class="card-title fw-bold mb-0">Weekend Watchlist</h5>
-            <span class="badge bg-light text-dark border">Private</span>
-          </div>
-          <p class="card-text text-secondary small mb-4">
-            Comedies and horror movies for the next movie night.
-          </p>
-
-          <div class="mt-auto">
-            <p class="text-secondary small mb-3">
-              <i class="bi bi-collection-play me-1"></i> 5 movies
-            </p>
-            <div class="d-grid">
-              <a href="#" class="btn btn-outline-secondary btn-sm">View List</a>
-            </div>
-          </div>
-        </div>
-      </div>
+    {% else %}
+    <div class="col-12 text-center py-5">
+      <p class="text-muted">You haven't created any lists yet. Click the button above to start creating custom lists.</p>
     </div>
-
-    <div class="col">
-      <div class="card h-100 shadow-sm border-0">
-        <div class="card-body p-4 d-flex flex-column">
-          <div class="d-flex justify-content-between align-items-start mb-2">
-            <h5 class="card-title fw-bold mb-0">Oscar 2026 Nominees</h5>
-            <span class="badge bg-light text-dark border">Shared</span>
-          </div>
-          <p class="card-text text-secondary small mb-4">
-            Keeping track of the awards season contenders.
-          </p>
-
-          <div class="mt-auto">
-            <p class="text-secondary small mb-3">
-              <i class="bi bi-collection-play me-1"></i> 8 movies
-            </p>
-            <div class="d-grid">
-              <a href="#" class="btn btn-outline-secondary btn-sm">View List</a>
+    {% endfor %}
+  </div>
+  <div class="modal fade" id="createListModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content border-0 shadow">
+        <div class="modal-header">
+          <h5 class="modal-title fw-bold">Create New List</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <form action="{{ url_for('main.create_list') }}" method="POST">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+          <div class="modal-body">
+            <div class="mb-3">
+              <label class="form-label fw-bold">List Name</label>
+              <input type="text" name="name" class="form-control" placeholder="Type the name of the list..." required />
+            </div>
+            <div class="mb-3">
+              <label class="form-label fw-bold">Description</label>
+              <textarea name="description" class="form-control" rows="3" placeholder="What the list is about..."></textarea>
+            </div>
+            <div class="form-check form-switch">
+              <!-- Functionality to be able to make the list public or private-->
+              <input class="form-check-input" type="checkbox" name="public_status" id="publicStatus" />
+              <label class="form-check-label" for="publicStatus">Make this list public</label>
             </div>
           </div>
-        </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-link text-secondary text-decoration-none" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-main">Create List</button>
+          </div>
+        </form>
       </div>
     </div>
   </div>

--- a/popcorn_journal_app/templates/movie_overview.html
+++ b/popcorn_journal_app/templates/movie_overview.html
@@ -78,13 +78,17 @@
 
             <div class="mt-4 p-3 bg-light rounded border col-lg-8">
               <h6 class="fw-bold mb-3 small text-secondary">Add to Personal List</h6>
-              <form class="d-flex gap-2">
-                <select name="list_id" class="form-select form-select-sm" required>
-                  <option value="" selected disabled>Select a list...</option>
-                  <option value="1">My Favorites</option>
-                  <option value="2">Plan to Watch</option>
-                </select>
-                <button type="submit" class="btn btn-sm btn-success px-3">Add</button>
+              <form action="{{ url_for('main.add_to_list', movie_id=movie.id) }}" method="POST">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                <div class="input-group">
+                  <select name="list_id" class="form-select form-select-sm">
+                    <option value="">Choose a list...</option>
+                    {% for user_list in current_user.lists %}
+                    <option value="{{ user_list.id }}">{{ user_list.name }}</option>
+                    {% endfor %}
+                  </select>
+                  <button type="submit" class="btn btn-main btn-sm">Add</button>
+                </div>
               </form>
             </div>
           </div>

--- a/popcorn_journal_app/templates/settings.html
+++ b/popcorn_journal_app/templates/settings.html
@@ -2,7 +2,7 @@
 
 <div class="container py-5">
   <h1 class="fw-bold mb-4">User Settings</h1>
-  <p class="text-secondary mb-4">Manage your account details, preferences, and privacy settings.</p>
+  <p class="text-secondary mb-4">Manage your account details.</p>
 
   <div class="card border-0 shadow-sm mb-4">
     <div class="card-body">
@@ -25,37 +25,29 @@
 
         <div class="mb-3">
           {{ form.profile_pic.label(class="form-label") }} {{ form.profile_pic(class="form-control") }}
-          <div class="form-text">Currently: {{ current_user.profile_pic or 'user.png' }}</div>
+          <div class="d-flex align-items-center mt-2">
+            <span class="text-secondary small me-2">Current:</span>
+            <img
+              src="{{ url_for('static', filename='profile_pics/' + (current_user.profile_pic or 'user.png')) }}"
+              class="rounded-circle border"
+              style="width: 40px; height: 40px; object-fit: cover"
+            />
+          </div>
         </div>
         {{ form.submit(class="btn btn-main") }}
       </form>
     </div>
-    <button class="btn danger-btn mt-3" onclick="deleteAccount('{{ current_user.id }}')">Delete Account</button>
+  </div>
+  <div class="card border-danger shadow-sm mb-4">
+    <div class="card-body p-4">
+      <h5 class="text-danger fw-bold mb-2">Danger Zone</h5>
+      <p class="text-secondary small">Once you delete your account, there is no going back. Please be certain.</p>
+      <button class="btn btn-outline-danger" id="delete-account-btn" data-user-id="{{ current_user.id }}" data-csrf="{{ csrf_token() }}">
+        Delete Account
+      </button>
+    </div>
   </div>
 </div>
-
-<script>
-  function deleteAccount(id) {
-    if (confirm("Are you sure? This action cannot be undone.")) {
-      fetch(`/user/delete/${id}`, {
-        method: "POST",
-        headers: {
-          "X-CSRFToken": "{{ csrf_token() }}",
-        },
-      })
-        .then((response) => {
-          if (response.redirected) {
-            window.location.href = response.url;
-          } else {
-            window.location.reload();
-          }
-        })
-        .catch((error) => {
-          console.error("Error:", error);
-          alert("An error occurred while deleting the account.");
-        });
-    }
-  }
-</script>
-
+{% endblock %} {% block scripts %}
+<script src="{{ url_for('static', filename='js/settings.js') }}"></script>
 {% endblock%}

--- a/popcorn_journal_app/templates/settings.html
+++ b/popcorn_journal_app/templates/settings.html
@@ -37,8 +37,11 @@
 <script>
   function deleteAccount(id) {
     if (confirm("Are you sure? This action cannot be undone.")) {
-      fetch(`/delete/${id}`, {
+      fetch(`/user/delete/${id}`, {
         method: "POST",
+        headers: {
+          "X-CSRFToken": "{{ csrf_token() }}",
+        },
       })
         .then((response) => {
           if (response.redirected) {


### PR DESCRIPTION
Involves the introduction of personal lists for users. 
For key features and fixes, I've added personal lists, allowing for creation, viewing, addition/removal of movies, and deleting, addressing #59 and #51. I also resolved a route collision that I encountered where list deletions were incorrectly triggering account deletions. I've also implemented cascading deletes so that deletion of a user account automatically cleans up personal lists and reviews, which touches upon #65.

I have also moved the js logic for deletion of an account from settings.html to its own settings.js