### PR TITLE
Jingbo add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,31 @@
 | 24598109 | Jingbo Wang | jingboouu |
 | 24502788 | Jennifer Le | jennifernhle |
 | 24310849 | Tony Zhang | zhiyizhang984-ops |
+
+## Running Tests
+
+This project uses `pytest` for automated testing. The tests create a temporary
+SQLite database, so they will not modify the local development database.
+
+Install dependencies:
+
+```bash
+python3 -m pip install -r requirements.txt
+```
+
+Run the test suite:
+
+```bash
+python3 -m pytest
+```
+
+The current test suite covers:
+
+- user registration, login, and logout
+- movie creation and local movie search
+- review creation, update, and deletion
+- watchlist add/remove behaviour
+- custom list creation and adding movies to lists
+- private list access control
+- follow/unfollow interactions
+- review like/unlike interactions

--- a/popcorn_journal_app/config.py
+++ b/popcorn_journal_app/config.py
@@ -20,7 +20,7 @@ class Config:
 
 class TestingConfig(Config):
     TESTING = True
-    SQLALCHEMY_DATABASE_URI = "sqlite3:///:memory:"
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     # Disabling of CSRF forms protection for testing
     WTF_CSRF_ENABLED = False
     USE_TMDB_API = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ Jinja2==3.1.6
 Mako==1.3.12
 MarkupSafe==3.0.3
 python-dotenv==1.2.1
+pytest==8.3.5
 requests==2.32.5
 SQLAlchemy==2.0.49
 tomli==2.4.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,77 @@
+import pytest
+from types import SimpleNamespace
+
+from popcorn_journal_app import create_app, db
+from popcorn_journal_app.config import TestingConfig
+from popcorn_journal_app.models import Movie, User
+
+
+class TestConfig(TestingConfig):
+    WTF_CSRF_ENABLED = False
+
+
+@pytest.fixture()
+def app(tmp_path):
+    class Config(TestConfig):
+        SQLALCHEMY_DATABASE_URI = f"sqlite:///{tmp_path / 'test.sqlite3'}"
+
+    app = create_app(Config)
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def user(app):
+    with app.app_context():
+        user = User(username="alice", email="alice@example.com")
+        user.set_password("Password1")
+        db.session.add(user)
+        db.session.commit()
+        return SimpleNamespace(id=user.id, username=user.username, email=user.email)
+
+
+@pytest.fixture()
+def other_user(app):
+    with app.app_context():
+        user = User(username="bob", email="bob@example.com")
+        user.set_password("Password1")
+        db.session.add(user)
+        db.session.commit()
+        return SimpleNamespace(id=user.id, username=user.username, email=user.email)
+
+
+@pytest.fixture()
+def movie(app, user):
+    with app.app_context():
+        movie = Movie(
+            title="Inception",
+            director="Christopher Nolan",
+            release_year=2010,
+            genre="Sci-Fi",
+            synopsis="A dream-sharing heist movie.",
+            creator_id=user.id,
+        )
+        db.session.add(movie)
+        db.session.commit()
+        return SimpleNamespace(id=movie.id, title=movie.title)
+
+
+@pytest.fixture()
+def login(client, user):
+    def _login(email="alice@example.com", password="Password1"):
+        return client.post(
+            "/login",
+            data={"email": email, "password": password, "remember": "y"},
+            follow_redirects=True,
+        )
+
+    return _login

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,49 @@
+from popcorn_journal_app.models import User
+
+
+def test_register_creates_user(client, app):
+    response = client.post(
+        "/register",
+        data={
+            "username": "newuser",
+            "email": "new@example.com",
+            "password": "Password1",
+            "confirm_password": "Password1",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Account created" in response.data
+
+    with app.app_context():
+        user = User.query.filter_by(email="new@example.com").first()
+        assert user is not None
+        assert user.check_password("Password1")
+
+
+def test_login_and_logout(client, user):
+    response = client.post(
+        "/login",
+        data={"email": "alice@example.com", "password": "Password1"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Logged in successfully" in response.data
+
+    response = client.get("/logout", follow_redirects=True)
+
+    assert response.status_code == 200
+    assert b"successfully logged out" in response.data
+
+
+def test_login_rejects_wrong_password(client, user):
+    response = client.post(
+        "/login",
+        data={"email": "alice@example.com", "password": "wrong-password"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Invalid email or password" in response.data

--- a/tests/test_lists_watchlist_social.py
+++ b/tests/test_lists_watchlist_social.py
@@ -1,0 +1,128 @@
+from popcorn_journal_app import db
+from popcorn_journal_app.models import List, Movie, Review, User
+
+
+def test_watchlist_toggle_adds_and_removes_movie(client, app, login, movie):
+    login()
+
+    response = client.post(f"/watchlist/toggle/{movie.id}")
+
+    assert response.status_code == 200
+    assert response.get_json()["action"] == "added"
+
+    with app.app_context():
+        user = User.query.filter_by(email="alice@example.com").first()
+        assert movie.id in [item.id for item in user.watchlist]
+
+    response = client.post(f"/watchlist/toggle/{movie.id}")
+
+    assert response.status_code == 200
+    assert response.get_json()["action"] == "removed"
+
+
+def test_user_can_create_list_and_add_movie(client, app, login, movie):
+    login()
+
+    response = client.post(
+        "/list/create",
+        data={
+            "name": "Weekend Picks",
+            "description": "Movies to watch this weekend.",
+            "public_status": "on",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"created successfully" in response.data
+
+    with app.app_context():
+        user_list = List.query.filter_by(name="Weekend Picks").first()
+        assert user_list is not None
+        list_id = user_list.id
+
+    response = client.post(
+        f"/list/add-movie/{movie.id}",
+        data={"list_id": list_id},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Added" in response.data
+
+    with app.app_context():
+        user_list = List.query.get(list_id)
+        assert movie.id in [item.id for item in user_list.movies]
+
+
+def test_private_list_is_not_visible_to_other_user(client, app, user, other_user, movie):
+    with app.app_context():
+        private_list = List(
+            name="Private Picks",
+            description="Only for Alice.",
+            public_status=False,
+            user_id=user.id,
+        )
+        private_list.movies.append(db.session.get(Movie, movie.id))
+        db.session.add(private_list)
+        db.session.commit()
+        list_id = private_list.id
+
+    client.post(
+        "/login",
+        data={"email": "bob@example.com", "password": "Password1"},
+        follow_redirects=True,
+    )
+    response = client.get(f"/list/{list_id}", follow_redirects=True)
+
+    assert response.status_code == 200
+    assert b"do not have permission" in response.data
+
+
+def test_follow_and_unfollow_user(client, app, login, other_user):
+    login()
+
+    response = client.post(f"/follow/{other_user.id}/follow")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["action"] == "unfollow"
+    assert payload["follower_count"] == 1
+
+    response = client.post(f"/follow/{other_user.id}/unfollow")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert payload["action"] == "follow"
+    assert payload["follower_count"] == 0
+
+
+def test_user_can_like_and_unlike_review(client, app, login, movie, other_user):
+    with app.app_context():
+        review = Review(
+            user_id=other_user.id,
+            movie_id=movie.id,
+            rating=8,
+            content="A strong recommendation.",
+        )
+        db.session.add(review)
+        db.session.commit()
+        review_id = review.id
+
+    login()
+
+    response = client.post(f"/like-review/{review_id}")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["action"] == "liked"
+    assert payload["count"] == 1
+
+    response = client.post(f"/like-review/{review_id}")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["action"] == "unliked"
+    assert payload["count"] == 0

--- a/tests/test_movies_reviews.py
+++ b/tests/test_movies_reviews.py
@@ -1,0 +1,80 @@
+from popcorn_journal_app.models import Movie, Review
+
+
+def test_logged_in_user_can_add_movie(client, app, login):
+    login()
+
+    response = client.post(
+        "/add-movie",
+        data={
+            "title": "Past Lives",
+            "director": "Celine Song",
+            "release_year": 2023,
+            "genre": "Drama",
+            "synopsis": "Childhood friends reconnect years later.",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"added to the database" in response.data
+
+    with app.app_context():
+        movie = Movie.query.filter_by(title="Past Lives").first()
+        assert movie is not None
+        assert movie.director == "Celine Song"
+
+
+def test_anonymous_user_cannot_add_movie(client):
+    response = client.get("/add-movie", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_search_finds_local_movie(client, movie):
+    response = client.get("/search?query=Inception")
+
+    assert response.status_code == 200
+    assert b"Inception" in response.data
+
+
+def test_user_can_create_update_and_delete_review(client, app, login, movie):
+    login()
+
+    response = client.post(
+        f"/movie/{movie.id}/review",
+        data={"rating": "9", "content": "A clever and visually strong film."},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Review posted" in response.data
+
+    with app.app_context():
+        review = Review.query.filter_by(movie_id=movie.id).first()
+        assert review is not None
+        assert review.rating == 9
+        review_id = review.id
+
+    response = client.post(
+        f"/movie/{movie.id}/review",
+        data={"rating": "8", "content": "Still excellent on rewatch."},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Review updated" in response.data
+
+    with app.app_context():
+        review = Review.query.get(review_id)
+        assert review.rating == 8
+        assert review.content == "Still excellent on rewatch."
+
+    response = client.post(f"/review/delete/{review_id}", follow_redirects=True)
+
+    assert response.status_code == 200
+    assert b"Review removed" in response.data
+
+    with app.app_context():
+        assert Review.query.get(review_id) is None


### PR DESCRIPTION
Added automated pytest coverage for the core Flask app flows.

- Added pytest fixtures with an isolated temporary SQLite test database
  - Added tests for user registration, login, logout, and invalid login
  - Added tests for movie creation and local movie search
  - Added tests for review creation, update, and deletion
  - Added tests for watchlist add/remove behaviour
  - Added tests for custom lists, private list access, follow/unfollow, and review like/unlike
  - Fixed the testing SQLite URI in `TestingConfig`
  - Added test running instructions to `README.md`
  - Added `pytest` to `requirements.txt`